### PR TITLE
Fix main app for first iteration

### DIFF
--- a/include/kernels/FVFunctorDivergence.h
+++ b/include/kernels/FVFunctorDivergence.h
@@ -1,0 +1,28 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "FVElementalKernel.h"
+
+class FVFunctorDivergence : public FVElementalKernel
+{
+public:
+  static InputParameters validParams();
+
+  FVFunctorDivergence(const InputParameters & parameters);
+
+protected:
+  ADReal computeQpResidual() override;
+
+  const Real _sign;
+  const Moose::Functor<ADReal> & _x;
+  const Moose::Functor<ADReal> & _y;
+  const Moose::Functor<ADReal> & _z;
+};

--- a/problems/FV_Channel_Main_App.i
+++ b/problems/FV_Channel_Main_App.i
@@ -71,6 +71,14 @@
     Ainv_y = Ainv_y
     Hu_x = Hhat_x
     Hu_y = Hhat_y
+    boundaries_to_force = 'left'
+  []
+  [divergence]
+    type = FVFunctorDivergence
+    sign = 1
+    x_functor = Hhat_x
+    y_functor = Hhat_y
+    variable = pressure_p
   []
   # [diff_v]
   #   type = FVDiffusion

--- a/src/kernels/FVFunctorDivergence.C
+++ b/src/kernels/FVFunctorDivergence.C
@@ -1,0 +1,62 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "FVFunctorDivergence.h"
+#include "Function.h"
+#include "FVUtils.h"
+
+registerMooseObject("AirfoilAppApp", FVFunctorDivergence);
+
+InputParameters
+FVFunctorDivergence::validParams()
+{
+  InputParameters params = FVElementalKernel::validParams();
+  params.addClassDescription(
+      "Computes the divergence of a vector field composed of component functors");
+  params.addRequiredParam<Real>("sign", "The sign of the divergence term");
+  params.addRequiredParam<MooseFunctorName>("x_functor", "The x-component functor.");
+  params.addParam<MooseFunctorName>("y_functor", 0, "The y-component functor.");
+  params.addParam<MooseFunctorName>("z_functor", 0, "The z-component functor.");
+  return params;
+}
+
+FVFunctorDivergence::FVFunctorDivergence(const InputParameters & parameters)
+  : FVElementalKernel(parameters),
+    _sign(getParam<Real>("sign")),
+    _x(getFunctor<ADReal>("x_functor")),
+    _y(getFunctor<ADReal>("y_functor")),
+    _z(getFunctor<ADReal>("z_functor"))
+{
+}
+
+ADReal
+FVFunctorDivergence::computeQpResidual()
+{
+  ADReal divergence = 0;
+
+  auto action_functor = [this, &divergence](const Elem & libmesh_dbg_var(functor_elem),
+                                            const Elem * neighbor,
+                                            const FaceInfo * const fi,
+                                            const Point & surface_vector,
+                                            Real,
+                                            bool) {
+    mooseAssert(&functor_elem == _current_elem, "these should be the same");
+    const auto elem_sub_id = _current_elem->subdomain_id();
+    const auto neighbor_sub_id = neighbor ? neighbor->subdomain_id() : Moose::INVALID_BLOCK_ID;
+    const auto cd_face = std::make_tuple(fi,
+                                         Moose::FV::LimiterType::CentralDifference,
+                                         true,
+                                         std::make_pair(elem_sub_id, neighbor_sub_id));
+    ADRealVectorValue face_vec(_x(cd_face), _y(cd_face), _z(cd_face));
+    divergence += face_vec * surface_vector;
+  };
+
+  Moose::FV::loopOverElemFaceInfo(*_current_elem, _mesh, _subproblem, action_functor);
+  return _sign * divergence / _assembly.elemVolume();
+}

--- a/src/kernels/FVNavStokesPredictor_p.C
+++ b/src/kernels/FVNavStokesPredictor_p.C
@@ -458,19 +458,6 @@ FVNavStokesPredictor_p::interpolate(Moose::FV::InterpMethod m, ADRealVectorValue
 
   if (onBoundary(*_face_info))
   {
-#ifndef NDEBUG
-    bool flow_boundary_found = false;
-    for (const auto b_id : _face_info->boundaryIDs())
-      if (_flow_boundaries.find(b_id) != _flow_boundaries.end())
-      {
-        flow_boundary_found = true;
-        break;
-      }
-
-    mooseAssert(flow_boundary_found,
-                "INSFV*Advection flux kernel objects should only execute on flow boundaries.");
-#endif
-
     v(0) = _u_var->getBoundaryFaceValue(*_face_info);
     if (_v_var)
       v(1) = _v_var->getBoundaryFaceValue(*_face_info);
@@ -586,24 +573,23 @@ FVNavStokesPredictor_p::computeQpResidual()
   // Compute the diffusion driven by the velocity gradient
   // Interpolate viscosity divided by porosity on the face
   ADReal mu_face;
-  Moose::FV::interpolate(Moose::FV::InterpMethod::Average,
-                         mu_face,
-                         mu_elem,
-                         mu_neighbor,
-                         *_face_info,
-                         true);
+  Moose::FV::interpolate(
+      Moose::FV::InterpMethod::Average, mu_face, mu_elem, mu_neighbor, *_face_info, true);
 
- // const auto mu_face = _mu(std::make_tuple(
- //     _face_info, Moose::FV::LimiterType::CentralDifference, true, faceArgSubdomains()));
+  // const auto mu_face = _mu(std::make_tuple(
+  //     _face_info, Moose::FV::LimiterType::CentralDifference, true, faceArgSubdomains()));
 
   // Compute face superficial velocity gradient
-  auto dudn = gradUDotNormal(); //_var.adGradSln(*_face_info) * _face_info->normal(); //Moose::FV::gradUDotNormal(_u_elem[_qp], _u_neighbor[_qp], *_face_info, _var);
+  auto dudn = gradUDotNormal(); //_var.adGradSln(*_face_info) * _face_info->normal();
+                                ////Moose::FV::gradUDotNormal(_u_elem[_qp], _u_neighbor[_qp],
+                                //*_face_info, _var);
 
   // First term of residual
-  const auto diffusion_residual = - 1.0 * mu_face * dudn; //mu_face * dudn;
+  const auto diffusion_residual = -1.0 * mu_face * dudn; // mu_face * dudn;
 
   // Pressure Residual
-  // const auto pressure_residual = _p_var->adGradSln(*_face_info)(_index) * _face_info->normal()(_index);
+  // const auto pressure_residual = _p_var->adGradSln(*_face_info)(_index) *
+  // _face_info->normal()(_index);
 
   // Time derivatives
   // ADReal time_residual = 0.;

--- a/src/kernels/FVNavStokesPressurePredictor_p.C
+++ b/src/kernels/FVNavStokesPressurePredictor_p.C
@@ -20,7 +20,7 @@ FVNavStokesPressurePredictor_p::validParams()
 
   params.addClassDescription("Object pressure predictor equation.");
   // Coupled variables
-  //params.addRequiredCoupledVar("pressure", "The pressure variable.");
+  // params.addRequiredCoupledVar("pressure", "The pressure variable.");
   // params.addRequiredCoupledVar("pressure_old", "The pressure old variable.");
   // params.addRequiredCoupledVar("u_star", "The velocity in the x direction.");
   // params.addCoupledVar("v_star", "The velocity in the y direction.");
@@ -48,8 +48,7 @@ FVNavStokesPressurePredictor_p::validParams()
 }
 
 FVNavStokesPressurePredictor_p::FVNavStokesPressurePredictor_p(const InputParameters & parameters)
-  :
-    // Base class
+  : // Base class
     FVFluxKernel(parameters),
 
     // Material properties
@@ -60,21 +59,29 @@ FVNavStokesPressurePredictor_p::FVNavStokesPressurePredictor_p(const InputParame
     // _p_var(dynamic_cast<const INSFVPressureVariable *>(getFieldVar("pressure", 0))),
     // _p_old(dynamic_cast<const INSFVPressureVariable *>(getFieldVar("pressure_old", 0))),
     // _u_star(dynamic_cast<const INSFVVelocityVariable *>(getFieldVar("u_star", 0))),
-    // _v_star(_mesh.dimension() >= 2 ? dynamic_cast<const INSFVVelocityVariable *>(getFieldVar("v_star", 0)) : nullptr),
-    // _w_star(_mesh.dimension() == 3 ? dynamic_cast<const INSFVVelocityVariable *>(getFieldVar("w_star", 0)) : nullptr),
+    // _v_star(_mesh.dimension() >= 2 ? dynamic_cast<const INSFVVelocityVariable
+    // *>(getFieldVar("v_star", 0)) : nullptr), _w_star(_mesh.dimension() == 3 ? dynamic_cast<const
+    // INSFVVelocityVariable *>(getFieldVar("w_star", 0)) : nullptr),
 
     // Get coupled predictor variables
     _Ainv_x(dynamic_cast<const MooseVariableFVReal *>(getFieldVar("Ainv_x", 0))),
-    _Ainv_y(_mesh.dimension() >= 2 ? dynamic_cast<const MooseVariableFVReal *>(getFieldVar("Ainv_y", 0)) : nullptr),
-    _Ainv_z(_mesh.dimension() >= 3 ? dynamic_cast<const MooseVariableFVReal *>(getFieldVar("Ainv_z", 0)) : nullptr),
+    _Ainv_y(_mesh.dimension() >= 2
+                ? dynamic_cast<const MooseVariableFVReal *>(getFieldVar("Ainv_y", 0))
+                : nullptr),
+    _Ainv_z(_mesh.dimension() >= 3
+                ? dynamic_cast<const MooseVariableFVReal *>(getFieldVar("Ainv_z", 0))
+                : nullptr),
 
     _Hu_x(dynamic_cast<const MooseVariableFVReal *>(getFieldVar("Hu_x", 0))),
-    _Hu_y(_mesh.dimension() >= 2 ? dynamic_cast<const MooseVariableFVReal *>(getFieldVar("Hu_y", 0)) : nullptr),
-    _Hu_z(_mesh.dimension() >= 3 ? dynamic_cast<const MooseVariableFVReal *>(getFieldVar("Hu_z", 0)) : nullptr),
+    _Hu_y(_mesh.dimension() >= 2 ? dynamic_cast<const MooseVariableFVReal *>(getFieldVar("Hu_y", 0))
+                                 : nullptr),
+    _Hu_z(_mesh.dimension() >= 3 ? dynamic_cast<const MooseVariableFVReal *>(getFieldVar("Hu_z", 0))
+                                 : nullptr),
 
     // _rhs_x(dynamic_cast<const MooseVariableFVReal *>(getFieldVar("rhs_x", 0))),
-    // _rhs_y(_mesh.dimension() >= 2 ? dynamic_cast<const MooseVariableFVReal *>(getFieldVar("rhs_y", 0)) : nullptr),
-    // _rhs_z(_mesh.dimension() >= 3 ? dynamic_cast<const MooseVariableFVReal *>(getFieldVar("rhs_z", 0)) : nullptr),
+    // _rhs_y(_mesh.dimension() >= 2 ? dynamic_cast<const MooseVariableFVReal
+    // *>(getFieldVar("rhs_y", 0)) : nullptr), _rhs_z(_mesh.dimension() >= 3 ? dynamic_cast<const
+    // MooseVariableFVReal *>(getFieldVar("rhs_z", 0)) : nullptr),
 
     // Variable numberings
     // _u_vel_star_var_number(coupled("u_star")),
@@ -87,9 +94,7 @@ FVNavStokesPressurePredictor_p::FVNavStokesPressurePredictor_p(const InputParame
 
 {
   std::cout << "Constructor OK" << std::endl;
-
 }
-
 
 ADReal
 FVNavStokesPressurePredictor_p::computeQpResidual()
@@ -111,21 +116,30 @@ FVNavStokesPressurePredictor_p::computeQpResidual()
               "Surely the neighbor has to match one of the face information's elements, right?");
 
   ADRealVectorValue neighbor_Ainv(_Ainv_x->getNeighborValue(neighbor, *_face_info, elem_Ainv(0)));
-                                   //* _face_info->neighborVolume());
+  //* _face_info->neighborVolume());
   if (_Ainv_y)
     neighbor_Ainv(1) = _Ainv_y->getNeighborValue(neighbor, *_face_info, elem_Ainv(1));
-                        //* _face_info->neighborVolume();
+  //* _face_info->neighborVolume();
   if (_Ainv_z)
     neighbor_Ainv(2) = _Ainv_z->getNeighborValue(neighbor, *_face_info, elem_Ainv(2));
-                       //* _face_info->neighborVolume();
+  //* _face_info->neighborVolume();
 
   ADRealVectorValue interp_Ainv_face;
-  Moose::FV::interpolate(Moose::FV::InterpMethod::Average,
-                         interp_Ainv_face,
-                         elem_Ainv,
-                         neighbor_Ainv,
-                         *_face_info,
-                         true);
+  if (onBoundary(*_face_info))
+  {
+    interp_Ainv_face(0) = _Ainv_x->getBoundaryFaceValue(*_face_info);
+    if (_Ainv_y)
+      interp_Ainv_face(1) = _Ainv_y->getBoundaryFaceValue(*_face_info);
+    if (_Ainv_z)
+      interp_Ainv_face(2) = _Ainv_z->getBoundaryFaceValue(*_face_info);
+  }
+  else
+    Moose::FV::interpolate(Moose::FV::InterpMethod::Average,
+                           interp_Ainv_face,
+                           elem_Ainv,
+                           neighbor_Ainv,
+                           *_face_info,
+                           true);
 
   ADRealVectorValue Ainv_gradp(interp_Ainv_face(0) * _var.adGradSln(*_face_info)(0));
   if (_Ainv_y)
@@ -133,52 +147,58 @@ FVNavStokesPressurePredictor_p::computeQpResidual()
   if (_Ainv_z)
     Ainv_gradp(2) = interp_Ainv_face(2) * _var.adGradSln(*_face_info)(2);
 
-  ADReal residual =  Ainv_gradp * _face_info->normal(); //* interp_Ainv_face;
+  ADReal residual = -Ainv_gradp * _face_info->normal(); //* interp_Ainv_face;
 
-  /// Divergence term
-  // Interpolating H to the faces
-  ADRealVectorValue elem_Hu(_Hu_x->getElemValue(elem));
-  if (_Hu_y)
-    elem_Hu(1) = _Hu_y->getElemValue(elem);
-  if (_Hu_z)
-    elem_Hu(2) = _Hu_z->getElemValue(elem);
+  // /// Divergence term
+  // // Interpolating H to the faces
+  // ADRealVectorValue elem_Hu(_Hu_x->getElemValue(elem));
+  // if (_Hu_y)
+  //   elem_Hu(1) = _Hu_y->getElemValue(elem);
+  // if (_Hu_z)
+  //   elem_Hu(2) = _Hu_z->getElemValue(elem);
 
-  ADRealVectorValue neighbor_Hu(_Hu_x->getNeighborValue(neighbor, *_face_info, elem_Hu(0)));
-  if (_Hu_y)
-    neighbor_Hu(1) = _Hu_y->getNeighborValue(neighbor, *_face_info, elem_Hu(1));
-  if (_Hu_z)
-    neighbor_Hu(2) = _Hu_z->getNeighborValue(neighbor, *_face_info, elem_Hu(2));
+  // ADRealVectorValue neighbor_Hu(_Hu_x->getNeighborValue(neighbor, *_face_info, elem_Hu(0)));
+  // if (_Hu_y)
+  //   neighbor_Hu(1) = _Hu_y->getNeighborValue(neighbor, *_face_info, elem_Hu(1));
+  // if (_Hu_z)
+  //   neighbor_Hu(2) = _Hu_z->getNeighborValue(neighbor, *_face_info, elem_Hu(2));
 
-  ADRealVectorValue interp_Hu_face;
-  Moose::FV::interpolate(Moose::FV::InterpMethod::Average,
-                         interp_Hu_face,
-                         elem_Hu,
-                         neighbor_Hu,
-                         *_face_info,
-                         true);
-
-  // Computing the divergence term
-  // auto Hu_div = interp_Hu_face(0) * _face_info->normal()(0);
-  //
-  // if (_mesh.dimension() >= 2)
+  // ADRealVectorValue interp_Hu_face;
+  // if (onBoundary(*_face_info))
   // {
-  //   Hu_div += interp_Hu_face(1) * _face_info->normal()(1);
+  //   interp_Hu_face(0) = _Hu_x->getBoundaryFaceValue(*_face_info);
+  //   if (_Hu_y)
+  //     interp_Hu_face(1) = _Hu_y->getBoundaryFaceValue(*_face_info);
+  //   if (_Hu_z)
+  //     interp_Hu_face(2) = _Hu_z->getBoundaryFaceValue(*_face_info);
   // }
-  // if (_mesh.dimension() >= 3)
-  // {
-  //   Hu_div += interp_Hu_face(2) * _face_info->normal()(2);
-  // }
+  // else
+  //   Moose::FV::interpolate(
+  //       Moose::FV::InterpMethod::Average, interp_Hu_face, elem_Hu, neighbor_Hu, *_face_info,
+  //       true);
 
-  residual += interp_Hu_face * _face_info->normal();
+  // // Computing the divergence term
+  // // auto Hu_div = interp_Hu_face(0) * _face_info->normal()(0);
+  // //
+  // // if (_mesh.dimension() >= 2)
+  // // {
+  // //   Hu_div += interp_Hu_face(1) * _face_info->normal()(1);
+  // // }
+  // // if (_mesh.dimension() >= 3)
+  // // {
+  // //   Hu_div += interp_Hu_face(2) * _face_info->normal()(2);
+  // // }
 
-  //std::cout << "Dif term:" << (Ainv_gradp * _face_info->normal()).value() << std::endl;
-  std::cout << "Src term x:" << (interp_Hu_face(0)).value() << std::endl;
-  std::cout << "Src term y:" << (interp_Hu_face(1)).value() << std::endl;
+  // residual -= interp_Hu_face * _face_info->normal();
+
+  // std::cout << "Dif term:" << (Ainv_gradp * _face_info->normal()).value() << std::endl;
+  // std::cout << "Src term x:" << (interp_Hu_face(0)).value() << std::endl;
+  // std::cout << "Src term y:" << (interp_Hu_face(1)).value() << std::endl;
 
   // if(_is_transient)
   //   residual -= (_rho(_current_elem)/_dt) * Hu_div;
 
-  //return _var.adGradSln(*_face_info) * _face_info->normal() + 1.0;
+  // return _var.adGradSln(*_face_info) * _face_info->normal() + 1.0;
   // std::cout << "This is my return: " <<
   //   1.0 * _var.adGradSln(*_face_info) * _face_info->normal() - 1.0 << std::endl;
 
@@ -189,8 +209,8 @@ FVNavStokesPressurePredictor_p::computeQpResidual()
   // std::cout << "Elem one is: " << elem_one_is_fi_elem << std::endl;
   // std::cout << "Counter: " << counter << std::endl;
   // ADReal constant_term = elem_one_is_fi_elem ?
-  //                       1.0 / _face_info->faceArea() / _face_info->faceCoord() / _face_info->elem().n_sides()
-  //                       : 0.0;
+  //                       1.0 / _face_info->faceArea() / _face_info->faceCoord() /
+  //                       _face_info->elem().n_sides() : 0.0;
 
   return residual;
 }


### PR DESCRIPTION
Pressure result from main app after first iteration:

<img width="1325" alt="Screen Shot 2021-11-10 at 7 30 55 PM" src="https://user-images.githubusercontent.com/10248304/141233613-3d4ed64b-f0d2-4d19-9dfb-bce5883380d8.png">

Key changes:
- The matrix in the notebook is the negative of the matrix that we create in MOOSE. The notebook has things like +div(grad(u)) in the notebook but it's -div(grad(u)) in MOOSE. So we do in fact need a different sign for the diffusion term and the divergence of H term
- We need to force execution of the flux kernel on the left face because there is no dirichlet BC there, so by default MOOSE does not run the flux kernel on that face

Something looks wrong in the sub-app for the second iteration, but I'm hoping it's just another sign issue like this one appears to have been